### PR TITLE
bug fixes and resources added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /barc4ro/version.py
 /.idea/
+*pycache*

--- a/barc4ro/barc4ro.py
+++ b/barc4ro/barc4ro.py
@@ -109,12 +109,11 @@ def srwl_opt_setup_CRL(_foc_plane, _delta, _atten_len, _shape, _apert_h, _apert_
                                       _r_min=_r_min, _n=surfs, _wall_thick=_wall_thick, _xc=_xc, _yc=_yc, _nx=_nx,
                                       _ny=_ny, _ang_rot_ex=_ang_rot_ex, _ang_rot_ey=_ang_rot_ey, _ang_rot_ez=_ang_rot_ez,
                                       _offst_ffs_x=_offst_ffs_x, _offst_ffs_y=_offst_ffs_y, _tilt_ffs_x=_tilt_ffs_x,
-                                      _tilt_ffs_y=_tilt_ffs_y, _ang_rot_ez_ffs=0, _wt_offst_ffs=_wt_offst_ffs,
+                                      _tilt_ffs_y=_tilt_ffs_y, _ang_rot_ez_ffs=_ang_rot_ez_ffs, _wt_offst_ffs=_wt_offst_ffs,
                                       _offst_bfs_x=_offst_bfs_x, _offst_bfs_y=_offst_bfs_y, _tilt_bfs_x=_tilt_bfs_x,
                                       _tilt_bfs_y=_tilt_bfs_y, _ang_rot_ez_bfs=_ang_rot_ez_bfs,
                                       _wt_offst_bfs=_wt_offst_bfs, isdgr=isdgr, project=True, _axis_x=None,
                                       _axis_y=None, _aperture='c')
-
 
     _xc = 0.0
     _yc = 0.0
@@ -164,22 +163,21 @@ def srwl_opt_setup_CRL_metrology(_height_prof_data, _mesh, _delta, _atten_len, _
     dx = (_mesh.xFin - _mesh.xStart) / _mesh.nx
     dy = (_mesh.yFin - _mesh.yStart) / _mesh.ny
 
-
     pad_y = int(_mesh.ny*0.1)
     pad_x = int(_mesh.nx*0.1)
 
     thcknss = np.pad(_height_prof_data, ((pad_y, pad_y),(pad_x, pad_x)), 'constant', constant_values=0)
 
     if _ang_rot_ex != 0 or _ang_rot_ey != 0:
-        print('OI')
+
         _ny, _nx = thcknss.shape
         xStart = - (dx * (_nx - 1)) / 2.0
         xFin = xStart + dx * (_nx - 1)
         yStart = - (dy * (_ny - 1)) / 2.0
         yFin = yStart + dy * (_ny - 1)
         _ny, _nx = thcknss.shape
-        x = np.linspace(_mesh.xStart, _mesh.xFin, _nx)
-        y = np.linspace(_mesh.yStart, _mesh.yFin, _ny)
+        x = np.linspace(xStart, xFin, _nx)
+        y = np.linspace(yStart, yFin, _ny)
         tilt = np.zeros(thcknss.shape)
         rz = thcknss
         rx, ry, rz = at_rotate_2D_nested_loop(x, y, rz, th_x=_ang_rot_ex, th_y=_ang_rot_ey, isdgr=isdgr)
@@ -253,4 +251,4 @@ def srwl_opt_setup_CRL_errors(_z_coeffs, _pol, _delta, _atten_len, _apert_h, _ap
     arTr[0::2] = np.reshape(amplitude_transmission,(_nx*_ny))
     arTr[1::2] = np.reshape(optical_path_diff,(_nx*_ny))
 
-    return SRWLOptT(_nx, _ny, xFin-xStart, yFin-yStart, _arTr=arTr, _extTr=1, _Fx=1e23, _Fy=1e23, _x=_xc, _y=_yc)
+    return SRWLOptT(_nx, _ny, xFin-xStart, yFin-yStart, _arTr=arTr, _extTr=1, _Fx=fx, _Fy=fy, _x=_xc, _y=_yc)

--- a/barc4ro/projected_thickness.py
+++ b/barc4ro/projected_thickness.py
@@ -92,6 +92,7 @@ def proj_thick_1D_crl(_shape, _apert_h, _r_min, _n=2, _wall_thick=0, _xc=0, _nx=
             x = np.linspace(-k * _apert_h, k * _apert_h, _nx)
         else:
             x = _axis
+
         # ========================================================
         # ========== Front Focusing Surface calculations =========
         # ========================================================
@@ -228,7 +229,7 @@ def proj_thick_1D_crl(_shape, _apert_h, _r_min, _n=2, _wall_thick=0, _xc=0, _nx=
 
 
 def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_thick=0, _xc=0, _yc=0, _nx=1001,
-                      _ny=1001,_ang_rot_ex=0, _ang_rot_ey=0, _ang_rot_ez=0, _offst_ffs_x=0, _offst_ffs_y=0,
+                      _ny=1001, _ang_rot_ex=0, _ang_rot_ey=0, _ang_rot_ez=0, _offst_ffs_x=0, _offst_ffs_y=0,
                       _tilt_ffs_x=0, _tilt_ffs_y=0, _ang_rot_ez_ffs=0, _wt_offst_ffs=0, _offst_bfs_x=0, _offst_bfs_y=0,
                       _tilt_bfs_x=0, _tilt_bfs_y=0, _ang_rot_ez_bfs=0,_wt_offst_bfs=0, isdgr=False, project=True,
                       _axis_x=None, _axis_y=None, _aperture=None):
@@ -341,6 +342,9 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
         neg_values_ffs_x = False
         neg_values_ffs_y = False
 
+        _apert_h_ffs = _apert_h
+        _apert_v_ffs = _apert_v
+
         if _foc_plane == 1 or _foc_plane == 3:
             if _wt_offst_ffs != 0:
                 _wall_thick_ffs = _wall_thick + _wt_offst_ffs*2
@@ -349,7 +353,6 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
                     neg_values_ffs_x = True
             else:
                 _wall_thick_ffs = _wall_thick
-                _apert_h_ffs = _apert_h
 
         if _foc_plane == 2 or _foc_plane == 3:
             neg_values_ffs_y = False
@@ -360,7 +363,6 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
                     neg_values_ffs_y = True
             else:
                 _wall_thick_ffs = _wall_thick
-                _apert_v_ffs = _apert_v
 
         # ------------- calculation of thickness profile in projection approximation
 
@@ -423,6 +425,8 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
             # ------------- new aperture resulting from different penetration depths
             neg_values_bfs_x = False
             neg_values_bfs_y = False
+            _apert_h_bfs = _apert_h
+            _apert_v_bfs = _apert_v
 
             if _foc_plane == 1 or _foc_plane == 3:
                 if _wt_offst_bfs != 0:
@@ -432,7 +436,6 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
                         neg_values_bfs_x = True
                 else:
                     _wall_thick_bfs = _wall_thick
-                    _apert_h_bfs = _apert_h
 
             if _foc_plane == 2 or _foc_plane == 3:
                 neg_values_bfs_y = False
@@ -443,7 +446,6 @@ def proj_thick_2D_crl(_foc_plane, _shape, _apert_h, _apert_v, _r_min, _n, _wall_
                         neg_values_bfs_y = True
                 else:
                     _wall_thick_bfs = _wall_thick
-                    _apert_v_bfs = _apert_v
 
             # ------------- calculation of thickness profile in projection approximation
 


### PR DESCRIPTION
1. Files changed:

**barc4ro.py:** 
small typos corrected and old 'prints' for debug deleted

**projected_thickness.py:**
in fuction  _proj_thick_2D_crl_ , when __foc_plane = 1_ or __foc_plane = 2_: the variables  __apert_v_bfs, _apert_h_bfs _apert_v_ffs, _apert_h_ffs_ are referenced before assignment. This merge solves this issue.

2. Files added:

pdf with the plot of all Zernike and Legendre polynomials for reference.